### PR TITLE
fix the node indexing bug in connecting nodes

### DIFF
--- a/scdiff2/scdiff2.py
+++ b/scdiff2/scdiff2.py
@@ -379,7 +379,7 @@ class Graph:
 
         # update the paga connectivity
         sc.tl.paga(prRes,groups='scdiff_cluster')
-        pagaConnects=pd.DataFrame(data=prRes.uns['paga']['connectivities_tree'].toarray())
+        pagaConnects=pd.DataFrame(data=prRes.uns['paga']['connectivities_tree'].toarray(),index=prRes.obs['scdiff_cluster'].cat.categories,columns=prRes.obs['scdiff_cluster'].cat.categories)
 
         # update nodes
         self.Nodes=self.__buildNodes(prRes.obs.scdiff_cluster,ncores)


### PR DESCRIPTION
Hi Jun, 

This is Hao from Ziv's group :) I'm using your scdiff2 and just found a bug when connecting the cell cluster nodes. Sometimes, an "IndexError: list index out of range" will be reported from line 600 in scdiff2.py. 
"""
jnode=[item for item in self.Nodes if item.ID==j][0]
"""

I found it's because in the later rounds, after cell reassignment, some nodes are empty and removed, and they won't appear in "self.Nodes", however, line 599 will traverse [0, N] when there are N nodes left.  For example, if four nodes [0,1,3,4] are left after cell reassignment, line 599 will traverse [0,1,2,3] instead of [0,1,3,4].

Creating the dataframe "pagaConnects" with the remaining node IDs in line 382 has been tested to address this problem. Please let me know if any comments. Thanks.

Best,
Hao

